### PR TITLE
11 유저 편의성 버튼 구현

### DIFF
--- a/finda2.0/src/App.tsx
+++ b/finda2.0/src/App.tsx
@@ -1,8 +1,17 @@
 import reactRouterObject from '@/pages/Router';
 import { RouterProvider } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import { darkMode, lightMode } from '@/globalStyles/GlobalTheme';
+import { darkAtom } from '@/atoms/dark';
+import { useAtomValue } from 'jotai';
 
 function Apps() {
-  return <RouterProvider router={reactRouterObject} />;
+  const isDarkMode = useAtomValue(darkAtom);
+  return (
+    <ThemeProvider theme={isDarkMode ? darkMode : lightMode}>
+      <RouterProvider router={reactRouterObject} />
+    </ThemeProvider>
+  );
 }
 
 export default Apps;

--- a/finda2.0/src/atoms/dark.ts
+++ b/finda2.0/src/atoms/dark.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const darkAtom = atom(true);

--- a/finda2.0/src/components/Panel/CircleBtn/index.style.ts
+++ b/finda2.0/src/components/Panel/CircleBtn/index.style.ts
@@ -1,0 +1,16 @@
+import { mixin } from '@/globalStyles/GlobalStyle';
+import styled from 'styled-components';
+
+export const CircleBtnWrap = styled.button<{ order: number }>`
+  ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
+  text-decoration: none;
+  border: none;
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border-radius: 999px;
+  transition: 0.5s;
+  background: ${({ theme }) => theme.pallete.normalBtn};
+  ${({ theme }) => theme.typography.Bold};
+  z-index: 20 + order * 5;
+`;

--- a/finda2.0/src/components/Panel/CircleBtn/index.style.ts
+++ b/finda2.0/src/components/Panel/CircleBtn/index.style.ts
@@ -1,7 +1,8 @@
 import { mixin } from '@/globalStyles/GlobalStyle';
+import { ShowPanelBtn } from '@components/Panel/Index.style';
 import styled from 'styled-components';
 
-export const CircleBtnWrap = styled.button<{ order: number }>`
+export const CircleBtnWrap = styled(ShowPanelBtn)<{ order: number }>`
   ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
   text-decoration: none;
   border: none;
@@ -12,5 +13,5 @@ export const CircleBtnWrap = styled.button<{ order: number }>`
   transition: 0.5s;
   background: ${({ theme }) => theme.pallete.normalBtn};
   ${({ theme }) => theme.typography.Bold};
-  z-index: 20 + order * 5;
+  z-index: ${({ order }) => 5 + order};
 `;

--- a/finda2.0/src/components/Panel/CircleBtn/index.style.ts
+++ b/finda2.0/src/components/Panel/CircleBtn/index.style.ts
@@ -2,7 +2,10 @@ import { mixin } from '@/globalStyles/GlobalStyle';
 import { ShowPanelBtn } from '@components/Panel/Index.style';
 import styled from 'styled-components';
 
-export const CircleBtnWrap = styled(ShowPanelBtn)<{ order: number }>`
+export const CircleBtnWrap = styled(ShowPanelBtn)<{
+  order: number;
+  isClicked: boolean;
+}>`
   ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
   text-decoration: none;
   border: none;
@@ -12,6 +15,8 @@ export const CircleBtnWrap = styled(ShowPanelBtn)<{ order: number }>`
   border-radius: 999px;
   transition: 0.5s;
   background: ${({ theme }) => theme.pallete.normalBtn};
-  ${({ theme }) => theme.typography.Bold};
-  z-index: ${({ order }) => 5 + order};
+  ${({ theme }) => theme.typography.Regular};
+  z-index: ${({ order }) => (!order ? 40 : 5 + order)};
+  color: ${({ theme }) => theme.pallete.normalFont};
+  bottom: ${({ order, isClicked }) => (isClicked ? `${order * 100}px` : '0')};
 `;

--- a/finda2.0/src/components/Panel/CircleBtn/index.style.ts
+++ b/finda2.0/src/components/Panel/CircleBtn/index.style.ts
@@ -1,8 +1,7 @@
 import { mixin } from '@/globalStyles/GlobalStyle';
-import { ShowPanelBtn } from '@components/Panel/Index.style';
 import styled from 'styled-components';
 
-export const CircleBtnWrap = styled(ShowPanelBtn)<{
+export const CircleBtnWrap = styled.button<{
   order: number;
   isClicked: boolean;
 }>`

--- a/finda2.0/src/components/Panel/CircleBtn/index.tsx
+++ b/finda2.0/src/components/Panel/CircleBtn/index.tsx
@@ -1,0 +1,32 @@
+import * as S from '@components/Panel/CircleBtn/index.style';
+
+export type infoType = {
+  clickEvent: () => void;
+  icon?: JSX.Element;
+  order: number;
+  text?: string;
+};
+
+type CircleBtnType = {
+  info: infoType;
+};
+
+function CircleBtn({ info }: CircleBtnType) {
+  const [clickEvent, order] = [info.clickEvent, info.order];
+  if (info.icon) {
+    const icon = info.icon;
+    return (
+      <S.CircleBtnWrap onClick={clickEvent} order={order}>
+        {icon}
+      </S.CircleBtnWrap>
+    );
+  }
+  const text = info.text;
+  return (
+    <S.CircleBtnWrap onClick={clickEvent} order={order}>
+      {text}
+    </S.CircleBtnWrap>
+  );
+}
+
+export default CircleBtn;

--- a/finda2.0/src/components/Panel/CircleBtn/index.tsx
+++ b/finda2.0/src/components/Panel/CircleBtn/index.tsx
@@ -9,21 +9,33 @@ export type infoType = {
 
 type CircleBtnType = {
   info: infoType;
+  isClicked: {
+    isClicked: boolean;
+    text: string;
+  };
 };
 
-function CircleBtn({ info }: CircleBtnType) {
+function CircleBtn({ info, isClicked }: CircleBtnType) {
   const [clickEvent, order] = [info.clickEvent, info.order];
   if (info.icon) {
     const icon = info.icon;
     return (
-      <S.CircleBtnWrap onClick={clickEvent} order={order}>
+      <S.CircleBtnWrap
+        onClick={clickEvent}
+        order={order}
+        isClicked={isClicked.isClicked}
+      >
         {icon}
       </S.CircleBtnWrap>
     );
   }
   const text = info.text;
   return (
-    <S.CircleBtnWrap onClick={clickEvent} order={order}>
+    <S.CircleBtnWrap
+      onClick={clickEvent}
+      order={order}
+      isClicked={isClicked.isClicked}
+    >
       {text}
     </S.CircleBtnWrap>
   );

--- a/finda2.0/src/components/Panel/Index.style.ts
+++ b/finda2.0/src/components/Panel/Index.style.ts
@@ -4,9 +4,24 @@ import styled from 'styled-components';
 export const PanelWrap = styled.div`
   position: fixed;
   ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
-  z-index:40;
+  z-index:50;
   bottom: 30px;
   right: 30px;
   width: 60px;
   height: 60px;
+  background: ${({ theme }) => theme.pallete.normalBtn};
+  border-radius: 999px;
+  ${({ theme }) => theme.typography.Bold};
+`;
+export const ShowPanelBtn = styled.button`
+  ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
+  text-decoration: none;
+  border: none;
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.pallete.normalBtn};
+  ${({ theme }) => theme.typography.Bold};
+  z-index: 40;
 `;

--- a/finda2.0/src/components/Panel/Index.style.ts
+++ b/finda2.0/src/components/Panel/Index.style.ts
@@ -13,16 +13,3 @@ export const PanelWrap = styled.div`
   border-radius: 999px;
   ${({ theme }) => theme.typography.Bold};
 `;
-export const ShowPanelBtn = styled.button`
-  ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
-  text-decoration: none;
-  border: none;
-  position: absolute;
-  width: 60px;
-  height: 60px;
-  border-radius: 999px;
-  background: ${({ theme }) => theme.pallete.normalBtn};
-  ${({ theme }) => theme.typography.Regular};
-  z-index: 40;
-  color: ${({ theme }) => theme.pallete.normalFont};
-`;

--- a/finda2.0/src/components/Panel/Index.style.ts
+++ b/finda2.0/src/components/Panel/Index.style.ts
@@ -22,6 +22,7 @@ export const ShowPanelBtn = styled.button`
   height: 60px;
   border-radius: 999px;
   background: ${({ theme }) => theme.pallete.normalBtn};
-  ${({ theme }) => theme.typography.Bold};
+  ${({ theme }) => theme.typography.Regular};
   z-index: 40;
+  color: ${({ theme }) => theme.pallete.normalFont};
 `;

--- a/finda2.0/src/components/Panel/Index.style.ts
+++ b/finda2.0/src/components/Panel/Index.style.ts
@@ -1,0 +1,12 @@
+import { mixin } from '@/globalStyles/GlobalStyle';
+import styled from 'styled-components';
+
+export const PanelWrap = styled.div`
+  position: fixed;
+  ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
+  z-index:40;
+  bottom: 30px;
+  right: 30px;
+  width: 60px;
+  height: 60px;
+`;

--- a/finda2.0/src/components/Panel/Index.tsx
+++ b/finda2.0/src/components/Panel/Index.tsx
@@ -12,18 +12,31 @@ function goTop() {
   window.scrollTo(0, 0);
 }
 function Panel() {
-  const [isClicked, setIsClicked] = useState(false);
+  const [isClicked, setIsClicked] = useState({
+    isClicked: false,
+    text: '펼치기',
+  });
 
   function showHiddenBtn(e: MouseEvent) {
     e.stopPropagation();
-    setIsClicked(true);
+    setIsClicked({
+      isClicked: true,
+      text: '접기',
+    });
   }
 
-  function toggleBtn(e: MouseEvent) {
-    e.stopPropagation();
-    setIsClicked(!isClicked);
+  function toggleBtn() {
+    setIsClicked({
+      isClicked: !isClicked,
+      text: isClicked ? '펼치기' : '접기',
+    });
   }
   const CircleBtnsInfo: CircleBtnInfoType[] = [
+    {
+      label: '펼치기',
+      clickEvent: toggleBtn,
+      text: isClicked.text,
+    },
     {
       label: '위로',
       clickEvent: goTop,
@@ -36,14 +49,11 @@ function Panel() {
     },
   ];
   const CircleBtns = CircleBtnsInfo.map((info, idx) => {
-    const btnInfo: infoType = { ...info, order: idx + 1 };
-    return <CircleBtn info={btnInfo} key={info.label} />;
+    const btnInfo: infoType = { ...info, order: idx };
+    return <CircleBtn info={btnInfo} key={info.label} isClicked={isClicked} />;
   });
   return (
-    <S.PanelWrap onMouseEnter={e => showHiddenBtn(e)}>
-      <S.ShowPanelBtn>{isClicked ? '접기' : '펼치기'}</S.ShowPanelBtn>
-      {CircleBtns}
-    </S.PanelWrap>
+    <S.PanelWrap onMouseEnter={e => showHiddenBtn(e)}>{CircleBtns}</S.PanelWrap>
   );
 }
 

--- a/finda2.0/src/components/Panel/Index.tsx
+++ b/finda2.0/src/components/Panel/Index.tsx
@@ -1,5 +1,6 @@
 import CircleBtn, { infoType } from '@components/Panel/CircleBtn';
 import * as S from '@components/Panel/Index.style';
+import { MouseEvent, useState } from 'react';
 
 export type CircleBtnInfoType = {
   label: string;
@@ -11,6 +12,17 @@ function goTop() {
   window.scrollTo(0, 0);
 }
 function Panel() {
+  const [isClicked, setIsClicked] = useState(false);
+
+  function showHiddenBtn(e: MouseEvent) {
+    e.stopPropagation();
+    setIsClicked(true);
+  }
+
+  function toggleBtn(e: MouseEvent) {
+    e.stopPropagation();
+    setIsClicked(!isClicked);
+  }
   const CircleBtnsInfo: CircleBtnInfoType[] = [
     {
       label: '위로',
@@ -27,7 +39,12 @@ function Panel() {
     const btnInfo: infoType = { ...info, order: idx + 1 };
     return <CircleBtn info={btnInfo} key={info.label} />;
   });
-  return <S.PanelWrap>{CircleBtns}</S.PanelWrap>;
+  return (
+    <S.PanelWrap onMouseEnter={e => showHiddenBtn(e)}>
+      <S.ShowPanelBtn>{isClicked ? '접기' : '펼치기'}</S.ShowPanelBtn>
+      {CircleBtns}
+    </S.PanelWrap>
+  );
 }
 
 export default Panel;

--- a/finda2.0/src/components/Panel/Index.tsx
+++ b/finda2.0/src/components/Panel/Index.tsx
@@ -1,0 +1,33 @@
+import CircleBtn, { infoType } from '@components/Panel/CircleBtn';
+import * as S from '@components/Panel/Index.style';
+
+export type CircleBtnInfoType = {
+  label: string;
+  clickEvent: () => void;
+  icon?: JSX.Element;
+  text?: string;
+};
+function goTop() {
+  window.scrollTo(0, 0);
+}
+function Panel() {
+  const CircleBtnsInfo: CircleBtnInfoType[] = [
+    {
+      label: '위로',
+      clickEvent: goTop,
+      text: '위로',
+    },
+    {
+      label: 'mock1',
+      clickEvent: () => {},
+      text: '더미',
+    },
+  ];
+  const CircleBtns = CircleBtnsInfo.map((info, idx) => {
+    const btnInfo: infoType = { ...info, order: idx + 1 };
+    return <CircleBtn info={btnInfo} key={info.label} />;
+  });
+  return <S.PanelWrap>{CircleBtns}</S.PanelWrap>;
+}
+
+export default Panel;

--- a/finda2.0/src/components/Panel/Index.tsx
+++ b/finda2.0/src/components/Panel/Index.tsx
@@ -1,6 +1,9 @@
 import CircleBtn, { infoType } from '@components/Panel/CircleBtn';
 import * as S from '@components/Panel/Index.style';
 import { MouseEvent, useState } from 'react';
+import { useAtom } from 'jotai';
+import { darkAtom } from '@/atoms/dark';
+import { MdDarkMode, MdLightMode } from 'react-icons/md';
 
 export type CircleBtnInfoType = {
   label: string;
@@ -11,11 +14,13 @@ export type CircleBtnInfoType = {
 function goTop() {
   window.scrollTo(0, 0);
 }
+
 function Panel() {
   const [isClicked, setIsClicked] = useState({
     isClicked: false,
     text: '펼치기',
   });
+  const [isDarkMode, setIsDarkMode] = useAtom(darkAtom);
 
   function showHiddenBtn(e: MouseEvent) {
     e.stopPropagation();
@@ -24,7 +29,9 @@ function Panel() {
       text: '접기',
     });
   }
-
+  function changeTheme() {
+    setIsDarkMode(!isDarkMode);
+  }
   function toggleBtn() {
     setIsClicked({
       isClicked: !isClicked,
@@ -43,9 +50,9 @@ function Panel() {
       text: '위로',
     },
     {
-      label: 'mock1',
-      clickEvent: () => {},
-      text: '더미',
+      label: '테마변경',
+      clickEvent: changeTheme,
+      icon: isDarkMode ? <MdDarkMode /> : <MdLightMode />,
     },
   ];
   const CircleBtns = CircleBtnsInfo.map((info, idx) => {

--- a/finda2.0/src/main.tsx
+++ b/finda2.0/src/main.tsx
@@ -2,14 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from '@/App';
 import { GlobalStyle } from '@/globalStyles/GlobalStyle';
-import { ThemeProvider } from 'styled-components';
-import { darkMode } from '@/globalStyles/GlobalTheme';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <GlobalStyle />
-    <ThemeProvider theme={darkMode}>
-      <App />
-    </ThemeProvider>
+    <App />
   </React.StrictMode>,
 );

--- a/finda2.0/src/pages/Layout.tsx
+++ b/finda2.0/src/pages/Layout.tsx
@@ -1,5 +1,6 @@
 import Footer from '@components/Footer/Index';
 import Header from '@components/Header/Index';
+import Panel from '@components/Panel/Index';
 
 type IndexType = {
   children: React.ReactNode;
@@ -10,6 +11,7 @@ function Layout({ children }: IndexType) {
     <div>
       <Header />
       {children}
+      <Panel />
       <Footer />
     </div>
   );


### PR DESCRIPTION
### 구현한 내용
 - [x] 레이아웃
 - [x] 위로 버튼
 - [x] 테마 변경 버튼
 - [x] 로그인/로그아웃 => 접기/펼치기 버튼으로 변경
    - 헤더에 이미 같은 기능이 있어서 제외

### 구현 방향
 - 유지 보수가 쉬운 구조로 구현
   - 객체에 버튼 구현에 필요한 정보를 넣으면 애니메이션, 배치, 렌더링이 자동으로 됨