### PR TITLE
47 서스펜스, 에러 바운더리 적용

### DIFF
--- a/finda2.0/package-lock.json
+++ b/finda2.0/package-lock.json
@@ -15,6 +15,7 @@
         "json-server": "^0.17.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.12",
         "react-icons": "^4.8.0",
         "react-router-dom": "6.4",
         "styled-components": "^5.3.10",
@@ -19281,6 +19282,17 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
@@ -36328,6 +36340,14 @@
           "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
           "dev": true
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-icons": {

--- a/finda2.0/package.json
+++ b/finda2.0/package.json
@@ -20,6 +20,7 @@
     "json-server": "^0.17.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-icons": "^4.8.0",
     "react-router-dom": "6.4",
     "styled-components": "^5.3.10",

--- a/finda2.0/src/components/Error/Index.style.ts
+++ b/finda2.0/src/components/Error/Index.style.ts
@@ -1,0 +1,35 @@
+import { mixin, viewSize } from '@/globalStyles/GlobalStyle';
+import styled from 'styled-components';
+
+export const ErrorWrap = styled.div`
+  ${mixin.flexbox({ horizontal: 'center', vertical: 'center', dir: 'column' })};
+  background-color: ${({ theme }) => theme.pallete.normalBg};
+  padding: 100px;
+  gap: 100px;
+  height: 100vh;
+`;
+
+export const Title = styled.span`
+  ${({ theme }) => theme.typography.Title};
+  color: ${({ theme }) => theme.pallete.normalFont};
+  @media screen and (${viewSize.mobile}) {
+    ${({ theme }) => theme.typography.Regular};
+  }
+`;
+export const Content = styled.span`
+  ${({ theme }) => theme.typography.Regular};
+`;
+export const Button = styled.button`
+  ${({ theme }) => theme.typography.Bold}
+  border:none;
+  background: ${({ theme }) => theme.pallete.normalBtn};
+`;
+export const ImgContainer = styled.figure`
+  ${mixin.flexbox({ horizontal: 'center', vertical: 'center' })}
+  width: 100%;
+  height: 100%;
+`;
+export const SorryImg = styled.img`
+  width: 200px;
+  height: 200px;
+`;

--- a/finda2.0/src/components/Error/Index.tsx
+++ b/finda2.0/src/components/Error/Index.tsx
@@ -1,0 +1,18 @@
+import * as S from '@components/Error/Index.style';
+import SorryImgSrc from '@/assets/b3fcnnrbp4iaf7epl48ef93vvo-4002569fd195ed02c1467425bb108063.png';
+import { FallbackProps } from 'react-error-boundary';
+
+function Error({ error, resetErrorBoundary }: FallbackProps) {
+  return (
+    <S.ErrorWrap>
+      <S.Title>에러가 발생했습니다</S.Title>
+      <S.ImgContainer>
+        <S.SorryImg src={SorryImgSrc} />
+      </S.ImgContainer>
+      <S.Content>{error.message}</S.Content>
+      <S.Button onClick={resetErrorBoundary}>다시해보기</S.Button>
+    </S.ErrorWrap>
+  );
+}
+
+export default Error;

--- a/finda2.0/src/components/Error/RouterError/Index.tsx
+++ b/finda2.0/src/components/Error/RouterError/Index.tsx
@@ -1,0 +1,18 @@
+import * as S from '@components/Error/Index.style';
+import SorryImgSrc from '@/assets/b3fcnnrbp4iaf7epl48ef93vvo-4002569fd195ed02c1467425bb108063.png';
+import { useRouteError } from 'react-router-dom';
+
+function RouterError() {
+  const error = useRouteError() as Error;
+  console.log(error);
+  return (
+    <S.ErrorWrap>
+      <S.Title>에러가 발생했습니다. 이전 페이지로 돌아가 주세요.</S.Title>
+      <S.ImgContainer>
+        <S.SorryImg src={SorryImgSrc} />
+      </S.ImgContainer>
+    </S.ErrorWrap>
+  );
+}
+
+export default RouterError;

--- a/finda2.0/src/components/Loading/Index.style.ts
+++ b/finda2.0/src/components/Loading/Index.style.ts
@@ -1,0 +1,43 @@
+import { mixin } from '@/globalStyles/GlobalStyle';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  ${mixin.flexbox({ dir: 'column', vertical: 'center', horizontal: 'center' })}
+  width: 100%;
+  margin: 3rem;
+  gap: 20px;
+`;
+
+export const Spinner = styled.div`
+  width: 30px;
+  height: 30px;
+  border: 4px solid ${({ theme }) => theme.pallete.normalFont};
+  border-top: 4px solid ${({ theme }) => theme.pallete.grey4};
+  border-radius: 50%;
+
+  -webkit-animation: spin 1s linear infinite;
+  animation: spin 1s linear infinite;
+
+  @-webkit-keyframes spin {
+    0% {
+      -webkit-transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+export const Copy = styled.span`
+  ${({ theme }) => theme.typography.Bold}
+  color: ${({ theme }) => theme.pallete.normalFont}
+`;

--- a/finda2.0/src/components/Loading/Index.tsx
+++ b/finda2.0/src/components/Loading/Index.tsx
@@ -1,0 +1,12 @@
+import * as S from '@components/Loading/Index.style';
+
+function Loading() {
+  return (
+    <S.Container>
+      <S.Spinner />
+      <S.Copy>로딩중...</S.Copy>
+    </S.Container>
+  );
+}
+
+export default Loading;

--- a/finda2.0/src/components/common/PageContainer/Index.style.ts
+++ b/finda2.0/src/components/common/PageContainer/Index.style.ts
@@ -1,7 +1,7 @@
 import { mixin } from '@/globalStyles/GlobalStyle';
 import styled from 'styled-components';
 
-export const Containter = styled.section`
+export const Container = styled.section`
   min-height: 100vh;
   width: 100%;
   ${mixin.flexbox({

--- a/finda2.0/src/components/common/PageContainer/Index.tsx
+++ b/finda2.0/src/components/common/PageContainer/Index.tsx
@@ -7,11 +7,11 @@ interface PageContainerType {
 
 function PageContainer({ children, size = 'space' }: PageContainerType) {
   return size === 'space' ? (
-    <S.Containter>
+    <S.Container>
       <S.InnerContainer>{children}</S.InnerContainer>
-    </S.Containter>
+    </S.Container>
   ) : (
-    <S.Containter>{children}</S.Containter>
+    <S.Container>{children}</S.Container>
   );
 }
 

--- a/finda2.0/src/main.tsx
+++ b/finda2.0/src/main.tsx
@@ -11,6 +11,7 @@ export const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       useErrorBoundary: true,
       refetchOnMount: false,
+      suspense: true,
     },
     mutations: {
       useErrorBoundary: true,

--- a/finda2.0/src/pages/Layout.tsx
+++ b/finda2.0/src/pages/Layout.tsx
@@ -1,6 +1,8 @@
+import Error from '@components/Error/Index';
 import Footer from '@components/Footer/Index';
 import Header from '@components/Header/Index';
 import Panel from '@components/Panel/Index';
+import { ErrorBoundary } from 'react-error-boundary';
 
 type IndexType = {
   children: React.ReactNode;
@@ -8,12 +10,12 @@ type IndexType = {
 
 function Layout({ children }: IndexType) {
   return (
-    <div>
+    <ErrorBoundary FallbackComponent={Error}>
       <Header />
       {children}
       <Panel />
       <Footer />
-    </div>
+    </ErrorBoundary>
   );
 }
 

--- a/finda2.0/src/pages/Movie.tsx
+++ b/finda2.0/src/pages/Movie.tsx
@@ -6,7 +6,7 @@ import { RankType } from '@components/common/Rank/type';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import Comments from '@components/Movie/Comments/Index';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import {
   getCommentsData,
   getMovieData,
@@ -14,6 +14,7 @@ import {
   postComments,
 } from '@/utils/API';
 import { sliceGenreArr } from '@/utils/util';
+import Loading from '@components/Loading/Index';
 
 function Movie() {
   const contentTitle = useParams().contentTitle as string;
@@ -119,9 +120,11 @@ function Movie() {
 
   return (
     <PageContainer size="full">
-      {detailData && <ContentInfo {...detailProps} />}
-      {similarData && <Rank {...similarMoviesProps} />}
-      {commentsData && <Comments {...commentProps} />}
+      <Suspense fallback={<Loading />}>
+        {detailData && <ContentInfo {...detailProps} />}
+        {similarData && <Rank {...similarMoviesProps} />}
+        {commentsData && <Comments {...commentProps} />}
+      </Suspense>
     </PageContainer>
   );
 }

--- a/finda2.0/src/pages/Movie.tsx
+++ b/finda2.0/src/pages/Movie.tsx
@@ -102,7 +102,8 @@ function Movie() {
       resetComment();
       window.alert('댓글이 등록되었습니다');
       queryClient.invalidateQueries({ queryKey: ['getCommentsQueryKey'] });
-    } else if (commentError) window.alert('댓글 등록 실패');
+    } else if (commentError)
+      window.alert('댓글 달기 실패, 관리자에게 문의하세요');
   }, [commentSuccess, commentError]);
 
   const detailProps = detailData! && {

--- a/finda2.0/src/pages/Result.tsx
+++ b/finda2.0/src/pages/Result.tsx
@@ -1,7 +1,7 @@
 import TitleResult from '@components/Result/TitleResult/Index';
 import PageContainer from '@components/common/PageContainer/Index';
 import { useParams } from 'react-router-dom';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, Suspense } from 'react';
 import {
   GenreType,
   NormalizedPosterDataType,
@@ -11,6 +11,7 @@ import * as S from '@components/Result/TitleResult/Index.style';
 import GenreResult from '@components/Result/GenreResult/Index';
 import { GENREINFO } from '@/assets/static';
 import { GenreResultPropsType } from '@components/Result/GenreResult/type';
+import Loading from '@components/Loading/Index';
 
 const getGenreText = (genreArr: number[]) => {
   const genreStringArr = genreArr.map(
@@ -92,7 +93,7 @@ function Result() {
     <PageContainer size="full">
       <S.ResultContatiner>
         <S.ResultTitle>{resultTitleText}</S.ResultTitle>
-        {ResultContent}
+        <Suspense fallback={<Loading />}>{ResultContent}</Suspense>
         <div className="InfinityScrollTrigger" ref={pageEndRef}></div>
       </S.ResultContatiner>
     </PageContainer>

--- a/finda2.0/src/pages/Router.tsx
+++ b/finda2.0/src/pages/Router.tsx
@@ -4,6 +4,7 @@ import Result from '@/pages/Result';
 import { createBrowserRouter } from 'react-router-dom';
 import Movie from '@/pages/Movie';
 import DB from '@pages/DB';
+import RouterError from '@components/Error/RouterError/Index';
 
 type RouterInfoType = {
   path: string;
@@ -50,10 +51,20 @@ const reactRouterObject = createBrowserRouter(
       ? {
           path: routerinfo.path,
           element: <Layout>{routerinfo.element}</Layout>, // layout 컴포넌트에 로그인 정보 넘겨줄 예정
+          errorElement: (
+            <Layout>
+              <RouterError />
+            </Layout>
+          ),
         }
       : {
           path: routerinfo.path,
           element: <Layout>{routerinfo.element}</Layout>,
+          errorElement: (
+            <Layout>
+              <RouterError />
+            </Layout>
+          ),
         };
   }),
 );


### PR DESCRIPTION
### 구현한 것
+ 에러 바운더리 적용
+ 서스펜스 적용

#### 에러 바운더리
+ react-error-boundary, react-router-dom의 Error Element 사용
  + 일반 에러는 react-error-boundary, 라우터 관련 에러는 react-router-dom 사용
  + ErrorElement를 사용해도 일반 에러를 캐치할 수 있지만, react-error-boundary의 reset 기능이 일반 에러 상황에서 적합하다 생각해 둘 다 사용

#### suspense 
 + 로딩 스핀 컴포넌트 구현해서 suspense 구현 

### 구현 과정
https://jjung5eung.notion.site/9e81c172b093457b85911d74c5f6f8e4?pvs=4

